### PR TITLE
upgrade Python and dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: Bootstrap poetry
         run: curl -sL https://install.python-poetry.org | python - -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: Ubuntu
             image: ubuntu-latest
@@ -23,16 +23,16 @@ jobs:
             image: macos-11
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Get full python version
         id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
 
       - name: Bootstrap poetry
         run: curl -sL https://install.python-poetry.org | python - -y
@@ -49,7 +49,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,15 @@ classifiers = [
 keywords = ["poetry", "vulnerabilities", "security", "audit"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-poetry = "^1.2.0"
-safety = "^2.2.0"
+python = "^3.8"
+poetry = "^1.6.1"
+safety = "^2.3.5"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^6.2"
+pytest = "^6.2.5"
 mypy  = "^0.942"
-black = "^22.3.0"
-isort = "^5.10.0"
+black = "^22.12.0"
+isort = "^5.12.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Hi @opeco17,  
I just discovered this great project. I wondered if the project is still actively maintained as apparently there hasn't been much activity lately.
So I upgraded the dependencies I discovered. Starting with Python 3.7 which has reached it's [end-of-life](https://devguide.python.org/versions/) I moved on to the GitHub Actions (`checkout`, `setup-python`, ...).
I also replaced the [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) `set-output` command. I then upgraded the pip dependencies using [`poetry up`](https://github.com/MousaZeidBaker/poetry-plugin-up).
Unfortunately the CI workflows testing this PR have failed.

I'd be very grateful if you would consider looking into this PR. This project has already been very helpful to me.
