### PR TITLE
feat: add caching and telemetry options

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Poetry plugin for checking security vulnerabilities in dependencies based on [safety](https://github.com/pyupio/safety).
 
-```
+```text
 $ poetry audit
 Scanning 19 packages...
 
@@ -15,7 +15,7 @@ Scanning 19 packages...
 
 ## Installation
 
-The easiest way to install the `export` plugin is via the `plugin add` command of Poetry.
+The easiest way to install the `audit` plugin is via the `plugin add` command of Poetry.
 
 ```bash
 poetry plugin add poetry-audit-plugin
@@ -46,9 +46,20 @@ poetry audit --ignore-code=CVE-2022-42969,CVE-2020-10684
 ```bash
 poetry audit --json --ignore-package=py,ansible-tower-cli
 ```
+
+* `--cache-db`: [Cache](https://github.com/pyupio/safety/blob/8b8a4039a7ed7d8b192e1d7175c7d2e0899cce33/safety/constants.py#L20) vulnerability database locally in `~/.safety/cache.json` --> default: `false`
+```bash
+poetry audit --cache-db true
+```
+
+* `--telemetry`: Toggle transmission of [telemetry](https://github.com/pyupio/safety/blob/8b8a4039a7ed7d8b192e1d7175c7d2e0899cce33/safety/util.py#L189) data by `safety` module --> default: `false`
+```bash
+poetry audit --telemetry true
+```
+
 ## Exit codes
 
-`poetry audit` will exit with a code indicating its status.
+`poetry audit` will exit with a code indicating it's status.
 
 * `0`: Vulnerabilities were not found.
 * `1`: One or more vulnerabilities were found.

--- a/poetry_audit_plugin/command.py
+++ b/poetry_audit_plugin/command.py
@@ -20,12 +20,16 @@ class AuditCommand(Command):
 
     options = [
         option("json", None, "Generate a JSON payload with the information of vulnerable packages.", flag=True),
-        option("ignore-code", None, "Ignore specified vulnerability codes", flag=False),
-        option("ignore-package", None, "Ignore specified packages", flag=False),
+        option("ignore-code", None, "Ignore specified vulnerability codes.", flag=False),
+        option("ignore-package", None, "Ignore specified packages.", flag=False),
+        option("cache-db", None, "Cache vulnerability database locally.", flag=False, default=False),
+        option("telemetry", None, "Activate telemetry of safety module.", flag=False, default=False),
     ]
 
     def handle(self) -> None:
         self.is_quiet = self.option("json")
+        self.cache_db = self.option("cache-db")
+        self.telemetry = self.option("telemetry")
 
         self.validate_lock_file()
 
@@ -40,7 +44,7 @@ class AuditCommand(Command):
         self.line(f"<info>Scanning {len(packages)} packages...</info>")
         self.line("")
 
-        all_vulnerable_packages = check_vulnerable_packages(packages)
+        all_vulnerable_packages = check_vulnerable_packages(packages, self.cache_db, self.telemetry)
 
         ignored_packages: List[str] = self.option("ignore-package").split(",") if self.option("ignore-package") else []
         ignored_codes: List[str] = self.option("ignore-code").split(",") if self.option("ignore-code") else []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,23 +21,23 @@ classifiers = [
     "Topic :: System :: Installation/Setup",
     "Topic :: System :: Software Distribution",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: MIT License"
 ]
 keywords = ["poetry", "vulnerabilities", "security", "audit"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-poetry = "^1.6.1"
+poetry = "^1.7.0"
 safety = "^2.3.5"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^6.2.5"
-mypy  = "^0.942"
-black = "^22.12.0"
+pytest = "^7.4.3"
+mypy  = "^1.7.0"
+black = "^23.11.0"
 isort = "^5.12.0"
 
 [build-system]
@@ -53,6 +53,9 @@ profile = "black"
 [tool.mypy]
 ignore_missing_imports = true
 check_untyped_defs = true
+
+[tool.ruff]
+line-length = 120
 
 [tool.poetry.plugins."poetry.application.plugin"]
 poetry-audit-plugin = "poetry_audit_plugin.plugin:AuditApplicationPlugin"


### PR DESCRIPTION
Hi @opeco17,
I just found this interesting plugin for poetry. I'm a happy user of poetry since a few days. I also discovered [`poetry up`](https://pypi.org/project/poetry-plugin-up/) and tested it on this repo.

After upgrading the pip requirements I read more about the `safety` module. Apparently they enable **telemetry** by default. So I added an option to this plugin to disable this behaviour.

I also learnt that the **caching** of the `PyUp` database used by `safety` is apparently disabled by default. So I also added a option to cache the database for 1 hour on the hard disk (they use a JSON file in `~/.safety/cache.json` sized ca. 130kb).

Unfortunately I didn't manage to get the tests working :(