### PR TITLE
Fix install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Scanning 19 packages...
 
 ## Installation
 
-The easiest way to install the `audit` plugin is via the `plugin add` command of Poetry.
+The easiest way to install the `audit` plugin is via the `self add` command of Poetry.
 
 ```bash
-poetry plugin add poetry-audit-plugin
+poetry self add poetry-audit-plugin
 ```
 
 If you used `pipx` to install Poetry you can add the plugin via the `pipx inject` command.


### PR DESCRIPTION
According to [this document](https://python-poetry.org/docs/main/), `poetry plugin add` is not used.