### PR TITLE
feat: add pre-commit hook configuration to be used by other repositories

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: poetry-audit
+  name: poetry-audit
+  description: run poetry audit to check vulnerabilities in package
+  entry: poetry audit
+  language: python
+  language_version: python3


### PR DESCRIPTION
Hi @opeco17,
I was looking to use this package and thought a pre-commit hook would be useful. This change is be based on [poetry-plugin-export](https://github.com/python-poetry/poetry-plugin-export/tree/main)'s [pre-commit hook configuration](https://github.com/python-poetry/poetry-plugin-export/blob/main/.pre-commit-hooks.yaml)